### PR TITLE
Lint

### DIFF
--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -11,33 +11,33 @@ struct Breakpoint {
     original_breakpoint_word: i64,
 }
 
-static mut global_breakpoint: Breakpoint = Breakpoint {
+static mut GLOBAL_BREAKPOINT: Breakpoint = Breakpoint {
     shift: 0,
     target_address: InferiorPointer(0),
     aligned_address: InferiorPointer(0),
     original_breakpoint_word: 0,
 };
 
-fn step_over(inferior: TrapInferior, bp: Breakpoint) -> () {
+fn step_over(inferior: TrapInferior, bp: Breakpoint) {
     poke_text(inferior, bp.aligned_address, bp.original_breakpoint_word);
     set_instruction_pointer(inferior, bp.target_address);
     single_step(inferior);
 }
 
-fn set(inferior: TrapInferior, bp: Breakpoint) -> () {
+fn set(inferior: TrapInferior, bp: Breakpoint) {
     let mut modified = bp.original_breakpoint_word;
     modified &= !(0xFFi64 << bp.shift);
     modified |= 0xCCi64 << bp.shift;
     poke_text(inferior, bp.aligned_address, modified);
 }
 
-pub fn handle<F>(inf: Inferior, mut callback: &mut F) -> InferiorState
+pub fn handle<F>(inf: Inferior, callback: &mut F) -> InferiorState
 where
-    F: FnMut(TrapInferior, TrapBreakpoint) -> (),
+    F: FnMut(TrapInferior, TrapBreakpoint),
 {
     let inferior = inf.pid;
 
-    let bp = unsafe { global_breakpoint };
+    let bp = unsafe { GLOBAL_BREAKPOINT };
     match inf.state {
         InferiorState::Running => {
             callback(inferior, 0);
@@ -65,7 +65,7 @@ pub fn trap_inferior_set_breakpoint(inferior: TrapInferior, location: u64) -> Tr
     set(inferior, bp);
 
     unsafe {
-        global_breakpoint = bp;
+        GLOBAL_BREAKPOINT = bp;
     }
 
     0

--- a/src/ptrace_util/mod.rs
+++ b/src/ptrace_util/mod.rs
@@ -36,31 +36,27 @@ pub mod user {
     }
 }
 
-pub fn trace_me() -> () {
-    ptrace::traceme().ok().expect("Failed PTRACE_TRACEME");
+pub fn trace_me() {
+    ptrace::traceme().expect("Failed PTRACE_TRACEME");
 }
 
 pub fn get_instruction_pointer(pid: pid_t) -> InferiorPointer {
     let raw = ptrace::read_user(Pid::from_raw(pid), user::regs::RIP as ptrace::AddressType)
-        .ok()
         .expect("Failed PTRACE_PEEKUSER");
     InferiorPointer(raw as u64)
 }
 
-pub fn set_instruction_pointer(pid: pid_t, ip: InferiorPointer) -> () {
+pub fn set_instruction_pointer(pid: pid_t, ip: InferiorPointer) {
     ptrace::write_user(
         Pid::from_raw(pid),
         user::regs::RIP as ptrace::AddressType,
         ip.as_i64(),
     )
-    .ok()
     .expect("Failed PTRACE_POKEUSER");
 }
 
-pub fn cont(pid: pid_t) -> () {
-    ptrace::cont(Pid::from_raw(pid), None)
-        .ok()
-        .expect("Failed PTRACE_CONTINUE");
+pub fn cont(pid: pid_t) {
+    ptrace::cont(Pid::from_raw(pid), None).expect("Failed PTRACE_CONTINUE");
 }
 
 pub fn peek_text(pid: pid_t, address: InferiorPointer) -> i64 {
@@ -69,19 +65,13 @@ pub fn peek_text(pid: pid_t, address: InferiorPointer) -> i64 {
     //   so these two operations are currently equivalent.
     // So use ptrace::read which is ptrace(PTRACE_PEEKDATA, ...)
     // An alterantive would be to use libc::ptrace.
-    ptrace::read(Pid::from_raw(pid), address.as_voidptr())
-        .ok()
-        .expect("Failed PTRACE_PEEKTEXT")
+    ptrace::read(Pid::from_raw(pid), address.as_voidptr()).expect("Failed PTRACE_PEEKTEXT")
 }
 
-pub fn poke_text(pid: pid_t, address: InferiorPointer, value: i64) -> () {
-    ptrace::write(Pid::from_raw(pid), address.as_voidptr(), value)
-        .ok()
-        .expect("Failed PTRACE_POKETEXT")
+pub fn poke_text(pid: pid_t, address: InferiorPointer, value: i64) {
+    ptrace::write(Pid::from_raw(pid), address.as_voidptr(), value).expect("Failed PTRACE_POKETEXT")
 }
 
-pub fn single_step(pid: pid_t) -> () {
-    ptrace::step(Pid::from_raw(pid), None)
-        .ok()
-        .expect("Failed PTRACE_SINGLESTEP");
+pub fn single_step(pid: pid_t) {
+    ptrace::step(Pid::from_raw(pid), None).expect("Failed PTRACE_SINGLESTEP");
 }


### PR DESCRIPTION
Most of these are either removing unneeded `-> ()` as return type or getting rid of my newbie `.ok().expect()`.

Leave all lints regarding unused variables alone as I keep these as reminders that I'm missing tests or features.