### PR TITLE
Set breapoints using function names.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Joseph Kain <joekain@gmail.com>"]
 [dependencies]
 libc = "0.2.174"
 nix = {version = "0.30.1", features = ["process", "ptrace", "signal"]}
+object = "0.37"
 
 [lib]
 name = "rusty_trap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Joseph Kain <joekain@gmail.com>"]
 libc = "0.2.174"
 nix = {version = "0.30.1", features = ["process", "ptrace", "signal"]}
 object = "0.37"
+rustc-demangle = "0.1"
 
 [lib]
 name = "rusty_trap"

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -68,7 +68,7 @@ where
     };
 }
 
-pub fn trap_inferior_set_breakpoint(
+fn set_breakpoint_at_address(
     mut inferior: TrapInferior,
     location: u64,
 ) -> (TrapInferior, TrapBreakpoint) {
@@ -90,4 +90,12 @@ pub fn trap_inferior_set_breakpoint(
     );
 
     (inferior, InferiorPointer(location))
+}
+
+pub fn trap_inferior_set_breakpoint(
+    mut inferior: TrapInferior,
+    location: &str,
+) -> (TrapInferior, TrapBreakpoint) {
+    let address: u64 = 0x55555555b9f4;
+    return set_breakpoint_at_address(inferior, address);
 }

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -31,13 +31,13 @@ fn set(inferior: &TrapInferior, bp: &Breakpoint) {
     poke_text(inferior.pid, bp.aligned_address, modified);
 }
 
-fn find_breakpoint_matching_inferior_instruction_pointer(inf: &Inferior) -> Option<&Breakpoint> {
+fn find_breakpoint_matching_inferior_instruction_pointer(inf: &TrapInferior) -> Option<&Breakpoint> {
     let InferiorPointer(ip) = get_instruction_pointer(inf.pid);
     let ip = InferiorPointer(ip - 1);
     return inf.breakpoints.get(&ip);
 }
 
-pub fn handle<F>(inferior: &mut Inferior, callback: &mut F) -> InferiorState
+pub fn handle<F>(inferior: &mut TrapInferior, callback: &mut F) -> InferiorState
 where
     F: FnMut(&TrapInferior, TrapBreakpoint),
 {

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -69,9 +69,9 @@ where
 }
 
 fn set_breakpoint_at_address<'a>(
-    mut inferior: &'a mut TrapInferior<'a>,
+    inferior: &'a mut TrapInferior<'a>,
     location: u64
-) -> (&'a TrapInferior<'a>, TrapBreakpoint) {
+) -> (&'a mut TrapInferior<'a>, TrapBreakpoint) {
     let aligned_address = location & !0x7u64;
     let target_address = InferiorPointer(location);
     inferior.breakpoints.insert(
@@ -93,9 +93,9 @@ fn set_breakpoint_at_address<'a>(
 }
 
 pub fn trap_inferior_set_breakpoint<'a>(
-    mut inferior: &'a mut TrapInferior<'a>,
+    inferior: &'a mut TrapInferior<'a>,
     location: &str,
-) -> (&'a TrapInferior<'a>, TrapBreakpoint) {
+) -> (&'a mut TrapInferior<'a>, TrapBreakpoint) {
     let address: u64 = 0x55555555b9f4;
     return set_breakpoint_at_address(inferior, address);
 }

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -31,7 +31,7 @@ fn set(inferior: &TrapInferior, bp: &Breakpoint) {
     poke_text(inferior.pid, bp.aligned_address, modified);
 }
 
-fn find_breakpoint_matching_inferior_instruction_pointer(inf: &TrapInferior) -> Option<&Breakpoint> {
+fn find_breakpoint_matching_inferior_instruction_pointer<'a>(inf: &'a TrapInferior) -> Option<&'a Breakpoint> {
     let InferiorPointer(ip) = get_instruction_pointer(inf.pid);
     let ip = InferiorPointer(ip - 1);
     return inf.breakpoints.get(&ip);
@@ -92,10 +92,10 @@ fn set_breakpoint_at_address(
     (inferior, InferiorPointer(location))
 }
 
-pub fn trap_inferior_set_breakpoint(
-    mut inferior: TrapInferior,
+pub fn trap_inferior_set_breakpoint<'a>(
+    mut inferior: TrapInferior<'a>,
     location: &str,
-) -> (TrapInferior, TrapBreakpoint) {
+) -> (TrapInferior<'a>, TrapBreakpoint) {
     let address: u64 = 0x55555555b9f4;
     return set_breakpoint_at_address(inferior, address);
 }

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -100,14 +100,12 @@ pub fn trap_inferior_set_breakpoint<'a>(
 ) -> (&'a mut TrapInferior<'a>, TrapBreakpoint) {
     let mut address: u64 = 0;
 
-    const BASE: u64 = 0x555555554000;
-
     for symbol in inferior.obj.symbols() {
 	let name = format!("{:#}", demangle(symbol.name().unwrap()));
 	let symbol_address = symbol.address();
 	if name == location {
 	    println!("Found symbol {name} at 0x{symbol_address:x}");
-	    address = symbol_address + BASE;
+	    address = symbol_address + inferior.base_address;
 	    break;
 	}
     }

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -38,7 +38,7 @@ fn find_breakpoint_matching_inferior_instruction_pointer<'a>(
 ) -> Option<&'a Breakpoint> {
     let InferiorPointer(ip) = get_instruction_pointer(inf.pid);
     let ip = InferiorPointer(ip - 1);
-    return inf.breakpoints.get(&ip);
+    inf.breakpoints.get(&ip)
 }
 
 pub fn handle<F>(inferior: &mut TrapInferior, callback: &mut F) -> InferiorState
@@ -54,7 +54,7 @@ where
     }
     callback(inferior, bp.target_address);
     step_over(inferior, bp);
-    return match waitpid(Pid::from_raw(inferior.pid), None) {
+    match waitpid(Pid::from_raw(inferior.pid), None) {
         Ok(WaitStatus::Stopped(_pid, signal::SIGTRAP)) => {
             set(inferior, bp);
             cont(inferior.pid);
@@ -69,7 +69,7 @@ where
         }
         Ok(_) => panic!("Unexpected stop in breakpoint::handle"),
         Err(_) => panic!("Unhandled error in breakpoint::handle"),
-    };
+    }
 }
 
 fn set_breakpoint_at_address<'a>(
@@ -89,7 +89,7 @@ fn set_breakpoint_at_address<'a>(
     );
 
     set(
-        &inferior,
+        inferior,
         inferior.breakpoints.get(&target_address).unwrap(),
     );
 
@@ -112,5 +112,5 @@ pub fn trap_inferior_set_breakpoint<'a>(
         }
     }
 
-    return set_breakpoint_at_address(inferior, address);
+    set_breakpoint_at_address(inferior, address)
 }

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -68,10 +68,10 @@ where
     };
 }
 
-fn set_breakpoint_at_address(
-    mut inferior: TrapInferior,
-    location: u64,
-) -> (TrapInferior, TrapBreakpoint) {
+fn set_breakpoint_at_address<'a>(
+    mut inferior: &'a mut TrapInferior<'a>,
+    location: u64
+) -> (&'a TrapInferior<'a>, TrapBreakpoint) {
     let aligned_address = location & !0x7u64;
     let target_address = InferiorPointer(location);
     inferior.breakpoints.insert(
@@ -93,9 +93,9 @@ fn set_breakpoint_at_address(
 }
 
 pub fn trap_inferior_set_breakpoint<'a>(
-    mut inferior: TrapInferior<'a>,
+    mut inferior: &'a mut TrapInferior<'a>,
     location: &str,
-) -> (TrapInferior<'a>, TrapBreakpoint) {
+) -> (&'a TrapInferior<'a>, TrapBreakpoint) {
     let address: u64 = 0x55555555b9f4;
     return set_breakpoint_at_address(inferior, address);
 }

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -2,8 +2,8 @@ use inferior::*;
 use nix::sys::signal;
 use nix::sys::wait::*;
 use nix::unistd::Pid;
-use ptrace_util::*;
 use object::{Object, ObjectSymbol};
+use ptrace_util::*;
 use rustc_demangle::demangle;
 
 #[derive(Copy, Clone)]
@@ -33,7 +33,9 @@ fn set(inferior: &TrapInferior, bp: &Breakpoint) {
     poke_text(inferior.pid, bp.aligned_address, modified);
 }
 
-fn find_breakpoint_matching_inferior_instruction_pointer<'a>(inf: &'a TrapInferior) -> Option<&'a Breakpoint> {
+fn find_breakpoint_matching_inferior_instruction_pointer<'a>(
+    inf: &'a TrapInferior,
+) -> Option<&'a Breakpoint> {
     let InferiorPointer(ip) = get_instruction_pointer(inf.pid);
     let ip = InferiorPointer(ip - 1);
     return inf.breakpoints.get(&ip);
@@ -72,7 +74,7 @@ where
 
 fn set_breakpoint_at_address<'a>(
     inferior: &'a mut TrapInferior<'a>,
-    location: u64
+    location: u64,
 ) -> (&'a mut TrapInferior<'a>, TrapBreakpoint) {
     let aligned_address = location & !0x7u64;
     let target_address = InferiorPointer(location);
@@ -101,13 +103,13 @@ pub fn trap_inferior_set_breakpoint<'a>(
     let mut address: u64 = 0;
 
     for symbol in inferior.obj.symbols() {
-	let name = format!("{:#}", demangle(symbol.name().unwrap()));
-	let symbol_address = symbol.address();
-	if name == location {
-	    println!("Found symbol {name} at 0x{symbol_address:x}");
-	    address = symbol_address + inferior.base_address;
-	    break;
-	}
+        let name = format!("{:#}", demangle(symbol.name().unwrap()));
+        let symbol_address = symbol.address();
+        if name == location {
+            println!("Found symbol {name} at 0x{symbol_address:x}");
+            address = symbol_address + inferior.base_address;
+            break;
+        }
     }
 
     return set_breakpoint_at_address(inferior, address);

--- a/src/breakpoint/mod.rs
+++ b/src/breakpoint/mod.rs
@@ -88,10 +88,7 @@ fn set_breakpoint_at_address<'a>(
         },
     );
 
-    set(
-        inferior,
-        inferior.breakpoints.get(&target_address).unwrap(),
-    );
+    set(inferior, inferior.breakpoints.get(&target_address).unwrap());
 
     (inferior, InferiorPointer(location))
 }

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -16,11 +16,11 @@ pub enum InferiorState {
 }
 
 #[derive(Clone)]
-pub struct TrapInferior {
+pub struct TrapInferior<'a> {
     pub pid: pid_t,
     pub state: InferiorState,
     pub breakpoints: HashMap<InferiorPointer, Breakpoint>,
-    obj: object::File,
+    obj: object::File<'a>,
 }
 
 impl TrapInferior {

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -4,6 +4,9 @@ use libc::pid_t;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::{Add, Sub};
+use object;
+use std::fs;
+use std::path::Path;
 
 #[derive(Copy, Clone)]
 pub enum InferiorState {
@@ -17,14 +20,17 @@ pub struct TrapInferior {
     pub pid: pid_t,
     pub state: InferiorState,
     pub breakpoints: HashMap<InferiorPointer, Breakpoint>,
+    obj: object::File,
 }
 
 impl TrapInferior {
-    pub fn new(pid: pid_t) -> TrapInferior {
+    pub fn new(pid: pid_t, path: &Path) -> TrapInferior {
+	let data = fs::read(path).unwrap();
         TrapInferior {
             pid,
             state: InferiorState::Stopped,
             breakpoints: HashMap::new(),
+            obj: object::File::parse(&*data).unwrap(),
         }
     }
 }

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -34,7 +34,7 @@ pub struct TrapInferior<'a> {
     pub pid: pid_t,
     pub state: InferiorState,
     pub breakpoints: HashMap<InferiorPointer, Breakpoint>,
-    obj: object::File<'a>,
+    pub obj: object::File<'a>,
 }
 
 impl <'a> TrapInferior<'a> {

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -8,6 +8,21 @@ use object;
 use std::fs;
 use std::path::Path;
 
+
+pub struct TrapData<'a> {
+    pub filename: &'a Path,
+    pub data: Vec<u8>,
+}
+
+impl <'a> TrapData<'a> {
+    pub fn new(filename: &Path) -> TrapData {
+	TrapData {
+	    filename: filename,
+	    data: fs::read(filename).unwrap()
+	}
+    }
+}
+
 #[derive(Copy, Clone)]
 pub enum InferiorState {
     Running,
@@ -23,14 +38,13 @@ pub struct TrapInferior<'a> {
     obj: object::File<'a>,
 }
 
-impl TrapInferior {
-    pub fn new(pid: pid_t, path: &Path) -> TrapInferior {
-	let data = fs::read(path).unwrap();
+impl <'a> TrapInferior<'a> {
+    pub fn new(pid: pid_t, trap_data: &'a TrapData<'a>) -> TrapInferior<'a> {
         TrapInferior {
             pid,
             state: InferiorState::Stopped,
             breakpoints: HashMap::new(),
-            obj: object::File::parse(&*data).unwrap(),
+            obj: object::File::parse(&*trap_data.data).unwrap(),
         }
     }
 }

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -30,7 +30,6 @@ pub enum InferiorState {
     SingleStepping,
 }
 
-#[derive(Clone)]
 pub struct TrapInferior<'a> {
     pub pid: pid_t,
     pub state: InferiorState,

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -17,7 +17,7 @@ pub struct TrapData<'a> {
 impl<'a> TrapData<'a> {
     pub fn new(filename: &Path) -> TrapData {
         TrapData {
-            filename: filename,
+            filename,
             data: fs::read(filename).unwrap(),
         }
     }
@@ -67,8 +67,7 @@ fn get_base_address(pid: pid_t, filename: &Path) -> u64 {
     }
     // This should be an error, there should be error handling.
     println!("Could not find base address for {expected}");
-    assert!(false);
-    0
+    panic!();
 }
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Hash)]
@@ -109,6 +108,6 @@ impl Sub<i64> for InferiorPointer {
 impl fmt::Display for InferiorPointer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &InferiorPointer(u) = self;
-        write!(f, "{}", u)
+        write!(f, "{u}")
     }
 }

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -13,23 +13,21 @@ pub enum InferiorState {
 }
 
 #[derive(Clone)]
-pub struct Inferior {
+pub struct TrapInferior {
     pub pid: pid_t,
     pub state: InferiorState,
     pub breakpoints: HashMap<InferiorPointer, Breakpoint>,
 }
 
-impl Inferior {
-    pub fn new(pid: pid_t) -> Inferior {
-        Inferior {
+impl TrapInferior {
+    pub fn new(pid: pid_t) -> TrapInferior {
+        TrapInferior {
             pid,
             state: InferiorState::Stopped,
             breakpoints: HashMap::new(),
         }
     }
 }
-
-pub type TrapInferior = Inferior;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Hash)]
 pub struct InferiorPointer(pub u64);

--- a/src/inferior/mod.rs
+++ b/src/inferior/mod.rs
@@ -1,26 +1,25 @@
 use breakpoint::Breakpoint;
 use libc::c_void;
 use libc::pid_t;
+use object;
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::{Add, Sub};
-use object;
 use std::fs;
-use std::path::Path;
 use std::io::{BufRead, BufReader};
-
+use std::ops::{Add, Sub};
+use std::path::Path;
 
 pub struct TrapData<'a> {
     pub filename: &'a Path,
     pub data: Vec<u8>,
 }
 
-impl <'a> TrapData<'a> {
+impl<'a> TrapData<'a> {
     pub fn new(filename: &Path) -> TrapData {
-	TrapData {
-	    filename: filename,
-	    data: fs::read(filename).unwrap()
-	}
+        TrapData {
+            filename: filename,
+            data: fs::read(filename).unwrap(),
+        }
     }
 }
 
@@ -39,14 +38,14 @@ pub struct TrapInferior<'a> {
     pub base_address: u64,
 }
 
-impl <'a> TrapInferior<'a> {
+impl<'a> TrapInferior<'a> {
     pub fn new(pid: pid_t, trap_data: &'a TrapData<'a>) -> TrapInferior<'a> {
         TrapInferior {
             pid,
             state: InferiorState::Stopped,
             breakpoints: HashMap::new(),
             obj: object::File::parse(&*trap_data.data).unwrap(),
-	    base_address: get_base_address(pid, trap_data.filename),
+            base_address: get_base_address(pid, trap_data.filename),
         }
     }
 }
@@ -59,19 +58,18 @@ fn get_base_address(pid: pid_t, filename: &Path) -> u64 {
     let expected = expected.to_str().unwrap();
     let reader = BufReader::new(file);
     for line in reader.lines() {
-	let line = line.unwrap();
-	if line.contains(expected) {
-	    let addr_str = line.split('-').next().unwrap();
-	    println!("Found base address 0x{addr_str}");
-	    return u64::from_str_radix(addr_str, 16).unwrap();
-	}
+        let line = line.unwrap();
+        if line.contains(expected) {
+            let addr_str = line.split('-').next().unwrap();
+            println!("Found base address 0x{addr_str}");
+            return u64::from_str_radix(addr_str, 16).unwrap();
+        }
     }
     // This should be an error, there should be error handling.
     println!("Could not find base address for {expected}");
     assert!(false);
     0
 }
-
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Hash)]
 pub struct InferiorPointer(pub u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate libc;
 extern crate nix;
 extern crate object;
+extern crate rustc_demangle;
 
 use libc::pid_t;
 use nix::sys::wait::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,18 @@ fn exec_inferior(filename: &Path, _args: &[&str]) {
 fn attach_inferior<'a>(raw_pid: pid_t, data: &'a TrapData) -> Result<TrapInferior<'a>, Error> {
     let nix_pid = Pid::from_raw(raw_pid);
     match waitpid(nix_pid, None) {
-        Ok(WaitStatus::Stopped(pid, signal::Signal::SIGTRAP)) => Ok(TrapInferior::new(pid.into(), data)),
+        Ok(WaitStatus::Stopped(pid, signal::Signal::SIGTRAP)) => {
+            Ok(TrapInferior::new(pid.into(), data))
+        }
         Ok(_) => panic!("Unexpected stop in attach_inferior"),
         Err(e) => Err(e),
     }
 }
 
-pub fn trap_inferior_exec<'a>(data: &'a TrapData, args: &[&str]) -> Result<TrapInferior<'a>, Error> {
+pub fn trap_inferior_exec<'a>(
+    data: &'a TrapData,
+    args: &[&str],
+) -> Result<TrapInferior<'a>, Error> {
     loop {
         match unsafe { fork() } {
             Ok(ForkResult::Child) => {
@@ -70,7 +75,10 @@ pub fn trap_inferior_exec<'a>(data: &'a TrapData, args: &[&str]) -> Result<TrapI
     }
 }
 
-pub fn trap_inferior_continue<'a, F>(inferior: &'a mut TrapInferior, mut callback: F) -> (&'a TrapInferior<'a>, i32)
+pub fn trap_inferior_continue<'a, F>(
+    inferior: &'a mut TrapInferior,
+    mut callback: F,
+) -> (&'a TrapInferior<'a>, i32)
 where
     F: FnMut(&TrapInferior, TrapBreakpoint),
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 mod ptrace_util;
 
-mod inferior;
+pub mod inferior;
 use inferior::*;
 
 mod breakpoint;
@@ -69,7 +69,7 @@ pub fn trap_inferior_exec<'a>(data: &'a TrapData, args: &[&str]) -> Result<TrapI
     }
 }
 
-pub fn trap_inferior_continue<'a, F>(mut inferior: &'a mut TrapInferior, mut callback: F) -> (&'a TrapInferior<'a>, i32)
+pub fn trap_inferior_continue<'a, F>(inferior: &'a mut TrapInferior, mut callback: F) -> (&'a TrapInferior<'a>, i32)
 where
     F: FnMut(&TrapInferior, TrapBreakpoint),
 {
@@ -79,7 +79,7 @@ where
         inferior.state = match waitpid(Pid::from_raw(inferior.pid), None) {
             Ok(WaitStatus::Exited(_pid, code)) => return (inferior, code),
             Ok(WaitStatus::Stopped(_pid, signal::SIGTRAP)) => {
-                breakpoint::handle(&mut inferior, &mut callback)
+                breakpoint::handle(inferior, &mut callback)
             }
             Ok(WaitStatus::Stopped(_pid, signal)) => {
                 panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub fn trap_inferior_exec<'a>(data: &'a TrapData, args: &[&str]) -> Result<TrapI
     loop {
         match unsafe { fork() } {
             Ok(ForkResult::Child) => {
-                exec_inferior(filename, args);
+                exec_inferior(data.filename, args);
                 unreachable!();
             }
             Ok(ForkResult::Parent { child: pid }) => return attach_inferior(pid.into(), data),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub fn trap_inferior_exec<'a>(data: &'a TrapData, args: &[&str]) -> Result<TrapI
     }
 }
 
-pub fn trap_inferior_continue<F>(mut inferior: TrapInferior, mut callback: F) -> (TrapInferior, i32)
+pub fn trap_inferior_continue<'a, F>(mut inferior: &'a mut TrapInferior, mut callback: F) -> (&'a TrapInferior<'a>, i32)
 where
     F: FnMut(&TrapInferior, TrapBreakpoint),
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,16 +45,16 @@ fn exec_inferior(filename: &Path, _args: &[&str]) {
     unreachable!();
 }
 
-fn attach_inferior(raw_pid: pid_t) -> Result<Inferior, Error> {
+fn attach_inferior(raw_pid: pid_t) -> Result<TrapInferior, Error> {
     let nix_pid = Pid::from_raw(raw_pid);
     match waitpid(nix_pid, None) {
-        Ok(WaitStatus::Stopped(pid, signal::Signal::SIGTRAP)) => Ok(Inferior::new(pid.into())),
+        Ok(WaitStatus::Stopped(pid, signal::Signal::SIGTRAP)) => Ok(TrapInferior::new(pid.into())),
         Ok(_) => panic!("Unexpected stop in attach_inferior"),
         Err(e) => Err(e),
     }
 }
 
-pub fn trap_inferior_exec(filename: &Path, args: &[&str]) -> Result<Inferior, Error> {
+pub fn trap_inferior_exec(filename: &Path, args: &[&str]) -> Result<TrapInferior, Error> {
     loop {
         match unsafe { fork() } {
             Ok(ForkResult::Child) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,17 @@
 extern crate rusty_trap;
 use std::path::Path;
 
+use rusty_trap::inferior::TrapData;
+
+
 const ADDRESS_OF_MAIN: u64 = 0x55555555b9f4;
 const ADDRESS_OF_FOO: u64 = 0x55555555b9e0;
 
 #[test]
 fn it_can_exec() {
-    let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/twelve"), &[]).unwrap();
-    let (_inferior, exit_code) = rusty_trap::trap_inferior_continue(inferior, |_, _| {});
+    let data = TrapData::new(Path::new("./target/debug/twelve"));
+    let mut inferior = rusty_trap::trap_inferior_exec(&data, &[]).unwrap();
+    let (_inferior, exit_code) = rusty_trap::trap_inferior_continue(&mut inferior, |_, _| {});
     assert_eq!(12, exit_code);
 }
 
@@ -15,9 +19,10 @@ fn it_can_exec() {
 fn it_can_set_breakpoints() {
     let mut breakpoint_count: i32 = 0;
 
-    let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/twelve"), &[]).unwrap();
+    let data = TrapData::new(Path::new("./target/debug/twelve"));
+    let mut inferior = rusty_trap::trap_inferior_exec(&data, &[]).unwrap();
     let expected_pid = inferior.pid;
-    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(inferior, "twelve::main");
+    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(&mut inferior, "twelve::main");
     let (_, _) = rusty_trap::trap_inferior_continue(inferior, |passed_inferior, passed_bp| {
         assert_eq!(passed_inferior.pid, expected_pid);
         assert_eq!(passed_bp, bp);
@@ -31,9 +36,10 @@ fn it_can_set_breakpoints() {
 fn it_can_handle_a_breakpoint_more_than_once() {
     let mut breakpoint_count: i32 = 0;
 
-    let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/loop"), &[]).unwrap();
+    let data = TrapData::new(Path::new("./target/debug/loop"));
+    let mut inferior = rusty_trap::trap_inferior_exec(&data, &[]).unwrap();
     let expected_pid = inferior.pid;
-    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(inferior, "loop::foo");
+    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(&mut inferior, "loop::foo");
     rusty_trap::trap_inferior_continue(inferior, |passed_inferior, passed_bp| {
         assert_eq!(passed_inferior.pid, expected_pid);
         assert_eq!(passed_bp, bp);
@@ -48,9 +54,10 @@ fn it_can_handle_more_than_one_breakpoint() {
     let mut bp_main_count: i32 = 0;
     let mut bp_foo_count: i32 = 0;
 
-    let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/loop"), &[]).unwrap();
+    let  data = TrapData::new(Path::new("./target/debug/loop"));
+    let mut inferior = rusty_trap::trap_inferior_exec(&data, &[]).unwrap();
     let expected_pid = inferior.pid;
-    let (inferior, bp_main) = rusty_trap::trap_inferior_set_breakpoint(inferior, "loop::main");
+    let (inferior, bp_main) = rusty_trap::trap_inferior_set_breakpoint(&mut inferior, "loop::main");
     let (inferior, bp_foo) = rusty_trap::trap_inferior_set_breakpoint(inferior, "loop::foo");
     let (_, _) = rusty_trap::trap_inferior_continue(inferior, |passed_inferior, passed_bp| {
         assert_eq!(passed_inferior.pid, expected_pid);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,10 +3,6 @@ use std::path::Path;
 
 use rusty_trap::inferior::TrapData;
 
-
-const ADDRESS_OF_MAIN: u64 = 0x55555555b9f4;
-const ADDRESS_OF_FOO: u64 = 0x55555555b9e0;
-
 #[test]
 fn it_can_exec() {
     let data = TrapData::new(Path::new("./target/debug/twelve"));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,7 +17,7 @@ fn it_can_set_breakpoints() {
 
     let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/twelve"), &[]).unwrap();
     let expected_pid = inferior.pid;
-    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(inferior, 0x000055555555b821);
+    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(inferior, "twelve::main");
     let (_, _) = rusty_trap::trap_inferior_continue(inferior, |passed_inferior, passed_bp| {
         assert_eq!(passed_inferior.pid, expected_pid);
         assert_eq!(passed_bp, bp);
@@ -33,7 +33,7 @@ fn it_can_handle_a_breakpoint_more_than_once() {
 
     let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/loop"), &[]).unwrap();
     let expected_pid = inferior.pid;
-    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(inferior, ADDRESS_OF_FOO);
+    let (inferior, bp) = rusty_trap::trap_inferior_set_breakpoint(inferior, "loop::foo");
     rusty_trap::trap_inferior_continue(inferior, |passed_inferior, passed_bp| {
         assert_eq!(passed_inferior.pid, expected_pid);
         assert_eq!(passed_bp, bp);
@@ -50,8 +50,8 @@ fn it_can_handle_more_than_one_breakpoint() {
 
     let inferior = rusty_trap::trap_inferior_exec(Path::new("./target/debug/loop"), &[]).unwrap();
     let expected_pid = inferior.pid;
-    let (inferior, bp_main) = rusty_trap::trap_inferior_set_breakpoint(inferior, ADDRESS_OF_MAIN);
-    let (inferior, bp_foo) = rusty_trap::trap_inferior_set_breakpoint(inferior, ADDRESS_OF_FOO);
+    let (inferior, bp_main) = rusty_trap::trap_inferior_set_breakpoint(inferior, "loop::main");
+    let (inferior, bp_foo) = rusty_trap::trap_inferior_set_breakpoint(inferior, "loop::foo");
     let (_, _) = rusty_trap::trap_inferior_continue(inferior, |passed_inferior, passed_bp| {
         assert_eq!(passed_inferior.pid, expected_pid);
         if passed_bp == bp_main {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,7 +50,7 @@ fn it_can_handle_more_than_one_breakpoint() {
     let mut bp_main_count: i32 = 0;
     let mut bp_foo_count: i32 = 0;
 
-    let  data = TrapData::new(Path::new("./target/debug/loop"));
+    let data = TrapData::new(Path::new("./target/debug/loop"));
     let mut inferior = rusty_trap::trap_inferior_exec(&data, &[]).unwrap();
     let expected_pid = inferior.pid;
     let (inferior, bp_main) = rusty_trap::trap_inferior_set_breakpoint(&mut inferior, "loop::main");


### PR DESCRIPTION
Use the `object` crate to look up symbols name from the symbol table when setting breakpoints.